### PR TITLE
Relax numpy upper bound to support numpy >=2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 1
+  number: 2
 
 requirements:
   host:
@@ -22,7 +22,7 @@ requirements:
   run:
     - python >={{ python_min }},<4.0
     - requests >=2.32.3,<3.0.0
-    - numpy >=1.24.1,<2.0.0
+    - numpy >=1.24.1
     - pandas >=2.2.2,<3.0.0
     - zeep >=4.2.1,<5.0.0
 


### PR DESCRIPTION
## What

Relaxes the numpy pin from `numpy >=1.24.1,<2.0.0` to `numpy >=1.24.1`, and bumps the build number from `1` to `2`.

## Why

The upstream [`noaa_coops`](https://github.com/GClunies/noaa_coops) package has no numpy upper bound in `pyproject.toml` and works correctly with numpy 2.x. The current feedstock pin blocks installation on environments where numpy>=2 is required (increasingly common with newer Python versions).

Reported upstream: [GClunies/noaa_coops#70](https://github.com/GClunies/noaa_coops/issues/70)

## Checklist

- [x] Used a fork of the repo to propose changes
- [x] Bumped the build number (if the version is unchanged)
- [x] Reset the build number to 0 (if the version changed) — N/A, version unchanged
- [x] Re-rendered with the latest conda-smithy — N/A, only recipe/meta.yaml pin change

cc @ocefpaf (recipe maintainer)